### PR TITLE
Making is easier for a new comer to locate opentx university.

### DIFF
--- a/_posts/2017-01-24-opentx-university.md
+++ b/_posts/2017-01-24-opentx-university.md
@@ -1,0 +1,13 @@
+---
+layout: post
+title: "OpenTX University - Beginners & Advanced Guide"
+description: ""
+category: ""
+tags: [Documents, English]
+---
+{% include JB/setup %}
+OpenTX 2.1
+
+[OpenTX University - Beginners & Advanced Guide](http://open-txu.org)
+
+<iframe width="820" height="800" src="http://open-txu.org"></iframe>


### PR DESCRIPTION
It appears under links but a new comer will first go to documentation after the home page.