### PR TITLE
Add link to our manual to the homepage

### DIFF
--- a/documents.md
+++ b/documents.md
@@ -6,10 +6,16 @@ group: navigation
 ---
 {% include JB/setup %}
 
+
+
+
 <ul class="posts">
 
-<!-- Insert Fixed List Items Here -->
 
+<!-- Insert Fixed List Items Here -->
+<li>
+<img src="assets/images/flags/gb.png"> [OpenTX 2.2 manual](https://opentx.gitbooks.io/manual-for-opentx-2-2/)
+</li>
 {% for post in site.tags.Documents %}
   <div class="post_info">
     <li>


### PR DESCRIPTION
I think the manual deserves linking. The how to update Sport with X7 is worth a pointer in many cases.

 I am not 100% sure on the syntax and have no idea how to test this, feel free to change 